### PR TITLE
feat: 회원가입 및 로그인에 SHA-256 해시 + 솔트 적용 로직 추가 #1

### DIFF
--- a/src/main/java/jiohh/springlogin/user/model/User.java
+++ b/src/main/java/jiohh/springlogin/user/model/User.java
@@ -18,7 +18,7 @@ public class User {
 
     @Column(nullable = false, length = 50)
     private String userId;
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 255)
     private String password;
     @Column(nullable = false, length = 50)
     private String name;
@@ -26,10 +26,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-//    단방향으로 사용하기 위해 제거
-//    TODO JPQL으로 MEMO 조회
-//    @OneToMany(mappedBy = "user")
-//    private List<Memo> memos = new ArrayList<>();
 
     public User() {
     }

--- a/src/main/java/jiohh/springlogin/user/service/UserService.java
+++ b/src/main/java/jiohh/springlogin/user/service/UserService.java
@@ -8,6 +8,8 @@ import jiohh.springlogin.user.exception.DuplicateUserIdException;
 import jiohh.springlogin.user.model.Role;
 import jiohh.springlogin.user.model.User;
 import jiohh.springlogin.user.repository.UserRepository;
+import jiohh.springlogin.user.util.HashUtil;
+import jiohh.springlogin.user.util.SaltUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,7 +28,11 @@ public class UserService {
         Optional<User> userOptional = userRepository.findByUserId(loginRequestDto.getUserId());
         if (userOptional.isPresent()) {
             User user = userOptional.get();
-            if (user.getPassword().equals(loginRequestDto.getPassword())) {
+            String[] parts = user.getPassword().split("\\$");
+            String salt = parts[0];
+            String storedHash = parts[1];
+            String hash = HashUtil.sha256(salt + loginRequestDto.getPassword());
+            if (storedHash.equals(hash)) {
                 LoginSessionDto dto = LoginSessionDto.builder()
                         .id(user.getId())
                         .userId(user.getUserId())
@@ -44,9 +50,14 @@ public class UserService {
         if(userRepository.findByUserId(signUpRequestDto.getUserId()).isPresent()) {
             throw new DuplicateUserIdException("이미 존재하는 아이디입니다.");
         }
+        String salt = SaltUtil.generateSalt();
+        String password = signUpRequestDto.getPassword();
+        String hash = HashUtil.sha256(salt + password);
+        String encodedPassword = salt + "$" + hash;
+
         User user = User.builder()
                         .userId(signUpRequestDto.getUserId())
-                .password((signUpRequestDto.getPassword()))
+                .password(encodedPassword)
                 .name(signUpRequestDto.getName())
                 .role(Role.USER)
                 .build();

--- a/src/main/java/jiohh/springlogin/user/util/HashUtil.java
+++ b/src/main/java/jiohh/springlogin/user/util/HashUtil.java
@@ -1,0 +1,25 @@
+package jiohh.springlogin.user.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class HashUtil {
+    public static String sha256(String input){
+        try{
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available",e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/jiohh/springlogin/user/util/SaltUtil.java
+++ b/src/main/java/jiohh/springlogin/user/util/SaltUtil.java
@@ -1,0 +1,14 @@
+package jiohh.springlogin.user.util;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class SaltUtil {
+    private static final SecureRandom random = new SecureRandom();
+
+    public static String generateSalt() {
+        byte[] salt = new byte[16]; //16바이트 크기의 salt = 바이트로 변환하여 랜던값 높힘
+        random.nextBytes(salt); //전달된 바이트 배열을 무작위 값으로 채움
+        return Base64.getEncoder().encodeToString(salt);
+    }
+}


### PR DESCRIPTION
- SaltUtil, HashUtil 유틸 클래스 생성
  - 솔트는 16바이트 Base64 문자열로 생성
  - 해시는 SHA-256 + Hex 포맷으로 처리
- User 엔티티에서 password는 'salt$hash' 형식으로 저장
- 회원가입 시 솔트 생성 및 해시 후 저장
- 로그인 시 저장된 salt와 입력값으로 해시 재생성 후 비교

resolve #1 