### PR TITLE
[Fix] 리프레시 토큰이 중복 생성되는 버그 수정

### DIFF
--- a/jwt-login/src/main/java/jiohh/springlogin/README.md
+++ b/jwt-login/src/main/java/jiohh/springlogin/README.md
@@ -56,7 +56,7 @@
     }
   }
   ```
-- **실패 응답** (401 Unauthorized):
+- **실패 응답** (400 BAD REQUEST):
   ```json
   {
     "status": "error",

--- a/jwt-login/src/main/java/jiohh/springlogin/config/interceptor/JwtInterceptor.java
+++ b/jwt-login/src/main/java/jiohh/springlogin/config/interceptor/JwtInterceptor.java
@@ -23,6 +23,9 @@ public class JwtInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (request.getMethod().equals("OPTIONS")) {
+            return true;
+        }
         String accessToken = request.getHeader("Authorization");
         log.info("access token: {}", accessToken);
         if (accessToken == null || !accessToken.startsWith("Bearer ")) {

--- a/jwt-login/src/main/java/jiohh/springlogin/user/controller/LoginController.java
+++ b/jwt-login/src/main/java/jiohh/springlogin/user/controller/LoginController.java
@@ -56,7 +56,7 @@ public class LoginController {
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<ApiResponseDto<ReissueResponseDto>> reissueAccessToken(@CookieValue("refreshToken") String refreshToken) {
+    public ResponseEntity<ApiResponseDto<ReissueResponseDto>> reissueAccessToken(@CookieValue(value = "refreshToken", required = false) String refreshToken) {
         if (refreshToken == null || !jwtUtil.validationToken(refreshToken)) {
             throw new InvalidRefreshTokenException();
         }

--- a/jwt-login/src/main/java/jiohh/springlogin/user/handler/LoginExceptionHandler.java
+++ b/jwt-login/src/main/java/jiohh/springlogin/user/handler/LoginExceptionHandler.java
@@ -22,7 +22,7 @@ public class LoginExceptionHandler {
                 .code("INVALID_CREDENTIALS")
                 .message(e.getMessage())
                 .build();
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 
     @ExceptionHandler(SessionInvalidationException.class)

--- a/jwt-login/src/main/java/jiohh/springlogin/user/model/RefreshToken.java
+++ b/jwt-login/src/main/java/jiohh/springlogin/user/model/RefreshToken.java
@@ -31,4 +31,8 @@ public class RefreshToken {
 
     public RefreshToken() {
     }
+
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
 }

--- a/jwt-login/src/main/java/jiohh/springlogin/user/repository/RefreshTokenRepository.java
+++ b/jwt-login/src/main/java/jiohh/springlogin/user/repository/RefreshTokenRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository {
     void save(RefreshToken refreshToken);
-    Optional<RefreshToken> findByUserId(String userId);
+    Optional<RefreshToken> findByUserId(Long userId);
     Optional<RefreshToken> findByToken(String token);
     void deleteByToken(RefreshToken refreshToken);
     void deleteByUserId(String userId);

--- a/jwt-login/src/main/java/jiohh/springlogin/user/repository/RefreshTokenRepositoryImpl.java
+++ b/jwt-login/src/main/java/jiohh/springlogin/user/repository/RefreshTokenRepositoryImpl.java
@@ -22,7 +22,7 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     }
 
     @Override
-    public Optional<RefreshToken> findByUserId(String userId) {
+    public Optional<RefreshToken> findByUserId(Long userId) {
         String sql = "SELECT rt FROM RefreshToken rt WHERE rt.userId = :userId";
         TypedQuery<RefreshToken> query = em.createQuery(sql, RefreshToken.class);
         query.setParameter("userId", userId);


### PR DESCRIPTION
기존
로그인시 refresh 토큰 재발급

수정
DB 조회 후 기존 토큰 폐기 및 새로운 토큰 생성으로 변경

결과
<img width="1582" alt="스크린샷 2025-06-23 오후 4 42 44" src="https://github.com/user-attachments/assets/55133c97-5cf6-494e-9859-b884fe179fb7" />
리프레시 토큰이 계정당 하나 생성되도록 변경

resolve #4 


